### PR TITLE
Finish port to Win32 and polish build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ include_directories(${PROJECT_BINARY_DIR})
 set(LIBRARY_FILES mdns.h mdns.c mdnsd.h mdnsd.c)
 
 add_library(tinysvcmdns ${LIBRARY_FILES})
+target_include_directories(tinysvcmdns PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>)
 if(WIN32)
   target_link_libraries(tinysvcmdns wsock32 ws2_32)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ endif()
 set(MDNS_DYNAMIC_LINKING OFF)
 if(BUILD_SHARED_LIBS)
   set(MDNS_DYNAMIC_LINKING ON)
+  add_definitions(-DMDNS_DYNAMIC_LINKING_EXPORT)
 endif()
 
 configure_file("mdns_config.h.in" "${PROJECT_BINARY_DIR}/mdns_config.h")
@@ -40,7 +41,7 @@ include_directories(${PROJECT_BINARY_DIR})
 
 set(LIBRARY_FILES mdns.h mdns.c mdnsd.h mdnsd.c)
 
-add_library(tinysvcmdns SHARED ${LIBRARY_FILES})
+add_library(tinysvcmdns ${LIBRARY_FILES})
 if(WIN32)
   target_link_libraries(tinysvcmdns wsock32 ws2_32)
 endif()

--- a/mdns.c
+++ b/mdns.c
@@ -157,6 +157,24 @@ uint8_t *create_label(const char *txt) {
 	return s;
 }
 
+// creates a label suitable for use in a TXT entry
+// such labels are not subject to the 63 bytes restriction.
+// free() after use
+static uint8_t *create_txt_label(const char *txt) {
+	size_t len;
+	uint8_t *s;
+
+	assert(txt != NULL);
+	len = strlen(txt);
+
+	s = malloc(len + 2);
+	s[0] = (uint8_t)len;
+	strncpy((char *) s + 1, txt, len);
+	s[len + 1] = '\0';
+
+	return s;
+}
+
 // creates a uncompressed name label given a DNS name like "apple.b.com"
 // see http://www.tcpipguide.com/free/t_DNSNameNotationandMessageCompressionTechnique.htm
 // apple.b.com -> [5]apple[1]b[3]com
@@ -448,7 +466,7 @@ void rr_add_txt(struct rr_entry *rr_txt, const char *txt) {
 	txt_rec->next = malloc(sizeof(struct rr_data_txt));
 
 	txt_rec = txt_rec->next;
-	txt_rec->txt = create_label(txt);
+	txt_rec->txt = create_txt_label(txt);
 	txt_rec->next = NULL;
 }
 

--- a/mdns.c
+++ b/mdns.c
@@ -423,7 +423,7 @@ struct rr_entry *rr_create(uint8_t *name, enum rr_type type) {
 }
 
 void rr_set_nsec(struct rr_entry *rr_nsec, enum rr_type type) {
-	assert(rr_nsec->type = RR_NSEC);
+	assert(rr_nsec->type == RR_NSEC);
 	assert((type / 8) < sizeof(rr_nsec->data.NSEC.bitmap));
 
 	rr_nsec->data.NSEC.bitmap[ type / 8 ] = (uint8_t)(1 << (7 - (type % 8)));

--- a/mdns.h
+++ b/mdns.h
@@ -35,6 +35,10 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MALLOC_ZERO_STRUCT(x, type) \
 	x = malloc(sizeof(struct type)); \
 	memset(x, 0, sizeof(struct type));
@@ -201,5 +205,9 @@ uint8_t MDNS_EXPORT *join_nlabel(const uint8_t *n1, const uint8_t *n2);
 static MDNS_INLINE int cmp_nlabel(const uint8_t *L1, const uint8_t *L2) {
 	return strcmp((const char *) L1, (const char *) L2);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*!__MDNS_H__*/

--- a/mdns_config.h.in
+++ b/mdns_config.h.in
@@ -20,12 +20,12 @@
 /**
  * Function Export
  * --------------- */
-/* On Win32: Define UA_DYNAMIC_LINKING and UA_DYNAMIC_LINKING_EXPORT in order to
-   export symbols for a DLL. Define UA_DYNAMIC_LINKING only to import symbols
+/* On Win32: Define MDNS_DYNAMIC_LINKING and MDNS_DYNAMIC_LINKING_EXPORT in order to
+   export symbols for a DLL. Define MDNS_DYNAMIC_LINKING only to import symbols
    from a DLL.*/
 #cmakedefine MDNS_DYNAMIC_LINKING
-#ifdef _WIN32
-# ifdef MDNS_DYNAMIC_LINKING
+#if defined(_WIN32) && defined(MDNS_DYNAMIC_LINKING)
+# ifdef MDNS_DYNAMIC_LINKING_EXPORT
 #  ifdef __GNUC__
 #   define MDNS_EXPORT __attribute__ ((dllexport))
 #  else
@@ -33,7 +33,7 @@
 #  endif
 # else
 #  ifdef __GNUC__
-#   define MDNS_EXPORT __attribute__ ((dllexport))
+#   define MDNS_EXPORT __attribute__ ((dllimport))
 #  else
 #   define MDNS_EXPORT __declspec(dllimport)
 #  endif

--- a/mdnsd.h
+++ b/mdnsd.h
@@ -29,7 +29,7 @@
 #ifndef __MDNSD_H__
 #define __MDNSD_H__
 
-#include "mdns_config.h.in"
+#include "mdns_config.h"
 
 #include <stdint.h>
 

--- a/mdnsd.h
+++ b/mdnsd.h
@@ -33,6 +33,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct mdnsd;
 struct mdns_service;
 
@@ -51,10 +55,13 @@ void MDNS_EXPORT mdnsd_add_rr(struct mdnsd *svr, struct rr_entry *rr);
 
 // registers a service with the MDNS responder instance
 MDNS_EXPORT struct mdns_service *mdnsd_register_svc(struct mdnsd *svr, const char *instance_name,
-		const char *type, uint16_t port, const char *hostname, const char *txt[]);
+	const char *type, uint16_t port, const char *hostname, const char *txt[]);
 
 // destroys the mdns_service struct returned by mdnsd_register_svc()
 void MDNS_EXPORT mdns_service_destroy(struct mdns_service *srv);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif/*!__MDNSD_H__*/

--- a/testmdnsd.c
+++ b/testmdnsd.c
@@ -40,6 +40,13 @@
 #include "mdnsd.h"
 
 int main(int argc, char *argv[]) {
+#ifdef _WIN32
+	WORD wVersionRequested;
+	wVersionRequested = MAKEWORD(2, 2);
+	WSADATA wsaData;
+	WSAStartup(wVersionRequested, &wsaData);
+#endif
+
 	// create host entries
 	char *hostname = "my_host.local";
 
@@ -94,6 +101,10 @@ int main(int argc, char *argv[]) {
 	getchar();
 
 	mdnsd_stop(svr);
+
+#ifdef _WIN32
+	WSACleanup();
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
This PR fixes nearly all warnings that occur in a Win32 build.
This includes warnings about file handles on Win32 being `SOCKET` instead of `int`.

Two patches fix generic bugs:
- 1ae7e2e Fixes an issue where TXT records over 63 bytes would get truncated to NULL and crash.
- f684d7c Fixes a `=` in an assert.